### PR TITLE
Enable public release automation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -485,32 +485,21 @@ jobs:
       - name: List packages
         run: ls -R ./npm
         shell: bash
-      - name: Publish Dev
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish
+        if: contains(github.ref, "main")
         run: |
           npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
           npm config set scope "@platformatic"
-          npm publish --tag dev
-
-      # TODO: Maybe restrict by branch, not just commit format?
-      # TODO: Enable this when we're ready to go public.
-      # - name: Publish
-      #   run: |
-      #     npm config set provenance true
-      #     if git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+$";
-      #     then
-      #       echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      #       npm publish # --access public
-      #     elif git log -1 --pretty=%B | grep "^[0-9]\+\.[0-9]\+\.[0-9]\+";
-      #     then
-      #       echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      #       npm publish --tag next # --access public
-      #     else
-      #       echo "Not a release, skipping publish"
-      #     fi
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm config set provenance true
+          if git log -1 --pretty=%B | grep "^v?[0-9]\+\.[0-9]\+\.[0-9]\+$";
+          then
+            npm publish --access public
+          elif git log -1 --pretty=%B | grep "^v?[0-9]\+\.[0-9]\+\.[0-9]\+";
+          then
+            npm publish --tag next --access public
+          else
+            echo "Not a release, skipping publish"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This enables public release automation.

Once this has landed, any commit to `main` with the format `vX.X.X` will publish a release. It may include trailing text to publish a pre-release like `v1.2.3-pre`. The "v" prefix is also optional, so `X.X.X` is also supported.

All releases will be made with provenance enabled, for paper trail. 📝 