### PR TITLE
Fix SAPI shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ console.log(response.body.toString())
 ### `new Php(config)`
 
 * `config` {Object} Configuration object
+  * `argv` {String[]} Process arguments. **Default:** []
   * `docroot` {String} Document root for PHP. **Default:** process.cwd()
 * Returns: {Php}
 
@@ -67,6 +68,7 @@ Construct a new PHP instance to which to dispatch requests.
 import { Php } from '@platformatic/php-node'
 
 const php = new Php({
+  argv: process.argv,
   docroot: process.cwd()
 })
 ````

--- a/crates/php/src/sapi.rs
+++ b/crates/php/src/sapi.rs
@@ -201,6 +201,10 @@ pub extern "C" fn sapi_module_deactivate() -> c_int {
   {
     let mut globals = SapiGlobals::get_mut();
 
+    for i in 0..globals.request_info.argc {
+      drop_str(unsafe { *globals.request_info.argv.offset(i as isize) });
+    }
+
     globals.server_context = std::ptr::null_mut();
     globals.request_info.argc = 0;
     globals.request_info.argv = std::ptr::null_mut();


### PR DESCRIPTION
This makes it so each instance of Embed holds an Arc so that the underlying SAPI may be dropped when there are no more Embeds. A Weak is held to attempt to upgrade an existing SAPI for any future Embed constructions, but will construct a new SAPI any time one is unavailable via the Weak.