### PR TITLE
chore: change rmdir to rm

### DIFF
--- a/__test__/util.mjs
+++ b/__test__/util.mjs
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { writeFile, mkdir, rmdir } from 'node:fs/promises'
+import { writeFile, mkdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -54,7 +54,7 @@ export class MockRoot {
    * Cleanup the mock docroot
    */
   async clean() {
-    await rmdir(this.path, {
+    await rm(this.path, {
       recursive: true,
       force: true
     })


### PR DESCRIPTION
Hey there!
When running pnpm build on a fresh clone, the build fails because Cargo cannot fetch the ext-php-rs dependency. This happens because the dependency is referenced with an SSH URL, which requires authentication.

```bash
error: failed to get `ext-php-rs` as a dependency ...
Caused by:
  Unable to update ssh://git@github.com/platformatic/ext-php-rs.git
Caused by:
  failed to authenticate when downloading repository
```

Extra: removed deprecated rmdir from __test__/util.mjs