### PR TITLE
ext-php-rs does not need to be a ssh dep anymore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -145,10 +145,6 @@ jobs:
           ref: PHP-8.4
       - name: Install dependencies
         run: pnpm install
-      - name: Give GitHub Actions access to ext-php-rs
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: Fetch cargo dependencies
         run: cargo fetch --target ${{ matrix.settings.target }}
         shell: bash
@@ -200,8 +196,6 @@ jobs:
       - name: Build in docker
         uses: addnab/docker-run-action@v3
         if: ${{ matrix.settings.docker }}
-        env:
-          ID_RSA: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
         with:
           image: ${{ matrix.settings.docker }}
           options: '--user 0:0 -v ${{ github.workspace }}/.cargo-cache/git/db:/usr/local/cargo/git/db -v ${{ github.workspace }}/.cargo/registry/cache:/usr/local/cargo/registry/cache -v ${{ github.workspace }}/.cargo/registry/index:/usr/local/cargo/registry/index -v ${{ github.workspace }}:/build -w /build'
@@ -217,17 +211,6 @@ jobs:
             # Install pnpm
             corepack disable
             npm i -g pnpm
-
-            # Set up SSH key (to checkout ext-php-rs with cargo)
-            mkdir -p ~/.ssh
-            eval `ssh-agent -s`
-            echo "${{ secrets.SECRET_REPO_DEPLOY_KEY }}" | tr -d '\r' | ssh-add -
-            ssh-add -l
-            mkdir -p ~/.ssh
-            touch ~/.ssh/config
-            touch ~/.ssh/known_hosts
-            chmod -R 400 ~/.ssh
-            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
 
             # Build PHP
             cd php-src
@@ -366,10 +349,6 @@ jobs:
       - name: List packages
         run: ls -R ./npm
         shell: bash
-      - name: Give GitHub Actions access to ext-php-rs
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
       - name: Test bindings
         run: pnpm test
 

--- a/crates/php/Cargo.toml
+++ b/crates/php/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 bytes = "1.10.1"
 hostname = "0.4.1"
-ext-php-rs = { git = "ssh://git@github.com/platformatic/ext-php-rs.git" }
+ext-php-rs = { git = "https://github.com/platformatic/ext-php-rs.git" }
 # ext-php-rs = { path = "../../../ext-php-rs" }
 lang_handler = { path = "../lang_handler" }
 libc = "0.2.171"


### PR DESCRIPTION
Now that our ext-php-rs fork is public, we don't need the ssh checkout anymore, we can use https.

Fixes #35.