### PR TITLE
Support Laravel

### DIFF
--- a/__test__/handler.spec.mjs
+++ b/__test__/handler.spec.mjs
@@ -70,7 +70,7 @@ test('Capture exceptions', async (t) => {
   const res = await php.handleRequest(req)
 
   // TODO: should exceptions be thrown rather than message-captured?
-  t.assert(/Hello, from PHP!/.test(res.exception))
+  t.assert(/Uncaught Exception: Hello, from PHP!/.test(res.log))
 })
 
 test('Support request and response headers', async (t) => {

--- a/crates/php/src/strings.rs
+++ b/crates/php/src/strings.rs
@@ -1,53 +1,6 @@
-use std::{
-  ffi::{c_char, CString},
-  path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 use crate::EmbedRequestError;
-
-#[allow(dead_code)]
-pub(crate) fn default_cstr<S, V>(
-  default: S,
-  maybe: Option<V>,
-) -> Result<*mut c_char, EmbedRequestError>
-where
-  S: Into<String>,
-  V: Into<String>,
-{
-  cstr(match maybe {
-    Some(v) => v.into(),
-    None => default.into(),
-  })
-}
-
-pub(crate) fn nullable_cstr<S>(maybe: Option<S>) -> Result<*mut c_char, EmbedRequestError>
-where
-  S: Into<String>,
-{
-  match maybe {
-    Some(v) => cstr(v.into()),
-    None => Ok(std::ptr::null_mut()),
-  }
-}
-
-pub(crate) fn cstr<S: AsRef<str>>(s: S) -> Result<*mut c_char, EmbedRequestError> {
-  CString::new(s.as_ref())
-    .map_err(|_| EmbedRequestError::CStringEncodeFailed(s.as_ref().to_owned()))
-    .map(|cstr| cstr.into_raw())
-}
-
-#[allow(dead_code)]
-pub(crate) fn reclaim_str(ptr: *mut c_char) -> CString {
-  unsafe { CString::from_raw(ptr) }
-}
-
-#[allow(dead_code)]
-pub(crate) fn drop_str(ptr: *mut c_char) {
-  if ptr.is_null() {
-    return;
-  }
-  drop(reclaim_str(ptr));
-}
 
 pub(crate) fn translate_path<D, P>(docroot: D, request_uri: P) -> Result<PathBuf, EmbedRequestError>
 where

--- a/crates/php_node/src/request.rs
+++ b/crates/php_node/src/request.rs
@@ -14,10 +14,14 @@ pub struct PhpRequestSocketOptions {
   pub local_address: String,
   /// The numeric representation of the local port. For example, 80 or 21.
   pub local_port: u16,
+  /// The string representation of the local IP family, e.g., "IPv4" or "IPv6".
+  pub local_family: String,
   /// The string representation of the remote IP address.
   pub remote_address: String,
   /// The numeric representation of the remote port. For example, 80 or 21.
   pub remote_port: u16,
+  /// The string representation of the remote IP family, e.g., "IPv4" or "IPv6".
+  pub remote_family: String,
 }
 
 /// Options for creating a new PHP request.
@@ -84,9 +88,25 @@ impl PhpRequest {
       builder = builder.method(method)
     }
 
+    fn sock_addr(family: &str, address: &str, port: u16) -> String {
+      if family == "IPv6" {
+        format!("[{}]:{}", address, port)
+      } else {
+        format!("{}:{}", address, port)
+      }
+    }
+
     if let Some(socket) = options.socket {
-      let local_socket = format!("{}:{}", socket.local_address, socket.local_port);
-      let remote_socket = format!("{}:{}", socket.remote_address, socket.remote_port);
+      let local_socket = sock_addr(
+        &socket.local_family,
+        &socket.local_address,
+        socket.local_port,
+      );
+      let remote_socket = sock_addr(
+        &socket.local_family,
+        &socket.remote_address,
+        socket.remote_port,
+      );
 
       builder = builder
         .local_socket(&local_socket)

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,10 +8,14 @@ export interface PhpRequestSocketOptions {
   localAddress: string
   /** The numeric representation of the local port. For example, 80 or 21. */
   localPort: number
+  /** The string representation of the local IP family, e.g., "IPv4" or "IPv6". */
+  localFamily: string
   /** The string representation of the remote IP address. */
   remoteAddress: string
   /** The numeric representation of the remote port. For example, 80 or 21. */
   remotePort: number
+  /** The string representation of the remote IP family, e.g., "IPv4" or "IPv6". */
+  remoteFamily: string
 }
 /** Options for creating a new PHP request. */
 export interface PhpRequestOptions {


### PR DESCRIPTION
These are fixes for various issues I found while getting Laravel to work.

- Ensure script file and filename string are not held any longer than necessary
- No longer registering error handlers as they promote suppressed exceptions to fatal
- Flush should not mark headers as sent as a flush could occur partway through header sending if they are large enough
- Cookies must be read from the external request context, not request_info
- PHP_SELF and SCRIPT_NAME should use post-rewrite values
- Ensure IPv6 socket addresses are parsed correctly
- Moved to allocating all request info strings within the PHP memory manager--this gets us free leak detection and better certainty about thread safety.