### PR TITLE
Remove ssh-agent from lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,11 +48,5 @@ jobs:
       - name: Cargo fmt
         run: cargo fmt -- --check
 
-      # Clippy needs access to install ext-php-rs
-      - name: Give GitHub Actions access to ext-php-rs
-        uses: webfactory/ssh-agent@v0.5.4
-        with:
-          ssh-private-key: ${{ secrets.SECRET_REPO_DEPLOY_KEY }}
-
       - name: Clippy
         run: cargo clippy


### PR DESCRIPTION
Missed this when updating the ci.yml.