### PR TITLE
Typo on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,10 +486,10 @@ headers.set('Content-Type', 'application/json')
 headers.add('Accept', 'application/json')
 headers.add('Accept', 'text/html')
 
-for (const (name, value) of headers.entries()) {
-  // ('Content-Type', 'application/json')
-  // ('Accept', 'application/json')
-  // ('Accept', 'text/html')
+for (const [name, value] of headers.entries()) {
+  // ['Content-Type', 'application/json']
+  // ['Accept', 'application/json']
+  // ['Accept', 'text/html']
 }
 ```
 


### PR DESCRIPTION
I believe `headers.entries()` returns a *Map#entries()* like iterator so that `[key, value]` would work while `(key, value)` won't do what people think it does.