### PR TITLE
chore: unfork ext-php-rs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+EXT_PHP_RS_ALLOWED_BINDINGS = "php_execute_script,sapi_send_headers,sapi_get_default_content_type,php_register_variable,SAPI_OPTION_NO_CHDIR"

--- a/crates/php/Cargo.toml
+++ b/crates/php/Cargo.toml
@@ -14,8 +14,7 @@ path = "src/main.rs"
 [dependencies]
 bytes = "1.10.1"
 hostname = "0.4.1"
-ext-php-rs = { git = "https://github.com/platformatic/ext-php-rs.git" }
-# ext-php-rs = { path = "../../../ext-php-rs" }
+ext-php-rs = { version = "0.14.0", features = ["embed"] }
 lang_handler = { path = "../lang_handler", features = ["napi"] }
 libc = "0.2.171"
 once_cell = "1.21.0"

--- a/crates/php/src/sapi.rs
+++ b/crates/php/src/sapi.rs
@@ -10,10 +10,11 @@ use bytes::Buf;
 use ext_php_rs::{
   alloc::{efree, estrdup},
   builders::SapiBuilder,
-  embed::SapiModule,
+  embed::{
+    ext_php_rs_sapi_per_thread_init, ext_php_rs_sapi_shutdown, ext_php_rs_sapi_startup, SapiModule,
+  },
   // exception::register_error_observer,
   ffi::{
-    ext_php_rs_sapi_per_thread_init, ext_php_rs_sapi_shutdown, ext_php_rs_sapi_startup,
     php_module_shutdown, php_module_startup, php_register_variable, sapi_send_headers,
     sapi_shutdown, sapi_startup, ZEND_RESULT_CODE_SUCCESS,
   },


### PR DESCRIPTION
With this, we are now using the mainline ext-php-rs. All features have been upstreamed at this point, so we can archive our fork.